### PR TITLE
Update cocoapods before testing

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -18,6 +18,7 @@ default_platform(:ios)
 platform :ios do
   before_all do
     xcode_select("/Applications/Xcode\ 13.4.1.app")
+    cocoapods(podfile: "Example/Podfile")
   end
 
   desc "Test MapsIndoors app"


### PR DESCRIPTION
Make sure that the new MapsIndoors version is used for testing (and other updated pods as well)