### PR TITLE
Update Google Maps dependency to 7.3.0

### DIFF
--- a/MapsIndoors_GoogleMaps.podspec
+++ b/MapsIndoors_GoogleMaps.podspec
@@ -22,7 +22,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '13.0'
   s.swift_version = "5.0"
 
-  s.dependency 'GoogleMaps', '7.2.0'
+  s.dependency 'GoogleMaps', '7.3.0'
   s.dependency 'MapsIndoorsCore', s.version.to_s
   s.dependency 'ValueAnimator', '0.6.8'
 

--- a/README.md
+++ b/README.md
@@ -16,11 +16,16 @@ To run the example project, clone the repo, and run `pod install` from the Examp
 
 ## Installation
 
-MapsIndoors is available through [CocoaPods](http://cocoapods.org). To install
-it, simply add the following line to your Podfile:
+MapsIndoors is available through [CocoaPods](http://cocoapods.org). To install it, add one of the following lines to your Podfile, depending on which map engine you will be using, Google Maps or Mapbox:
 
+To use the Google Maps map engine add
 ```ruby
-pod "MapsIndoors"
+pod "MapsIndoors_GoogleMaps"
+```
+
+To use the Mapbox map engine add
+```ruby
+pod "MapsIndoors_Mapbox"
 ```
 
 ## Author


### PR DESCRIPTION
Update Google Maps dependency to 7.3.0 which enables running in Simulator on AppleSilicon with iOS newer than 13.7